### PR TITLE
Add deploy to fly on PR

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,18 @@
+# flyctl launch added from .gitignore
+# Python-generated files
+**/__pycache__
+**/*.py[oc]
+**/build
+**/dist
+**/wheels
+**/*.egg-info
+**/.DS_Store
+**/.ruff_cache
+**/.pytest_cache
+
+# Virtual environments
+**/.venv
+**/test_output
+**/.vscode
+**/.streamlit
+fly.toml

--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -1,0 +1,18 @@
+# See https://fly.io/docs/app-guides/continuous-deployment-with-github-actions/
+
+name: Fly Deploy
+on:
+  push:
+    branches:
+      - main
+jobs:
+  deploy:
+    name: Deploy app
+    runs-on: ubuntu-latest
+    concurrency: deploy-group    # optional: ensure only one action runs at a time
+    steps:
+      - uses: actions/checkout@v4
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - run: flyctl deploy --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.github/workflows/fly-review.yaml
+++ b/.github/workflows/fly-review.yaml
@@ -1,0 +1,34 @@
+name: Deploy Review App
+on:
+  # Run this workflow on every PR event. Existing review apps will be updated when the PR is updated.
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+
+env:
+  FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+  # Set these to your Fly.io organization and preferred region.
+  FLY_REGION: cdg
+  FLY_ORG: lactate-thresholds
+
+jobs:
+  review_app:
+    runs-on: ubuntu-latest
+    outputs:
+      url: ${{ steps.deploy.outputs.url }}
+    # Only run one deployment at a time per PR.
+    concurrency:
+      group: pr-${{ github.event.number }}
+
+    # Deploying apps with this "review" environment allows the URL for the app to be displayed in the PR UI.
+    # Feel free to change the name of this environment.
+    environment:
+      name: review
+      # The script in the `deploy` sets the URL output for each review app.
+      url: ${{ steps.deploy.outputs.url }}
+    steps:
+      - name: Get code
+        uses: actions/checkout@v4
+
+      - name: Deploy PR app to Fly.io
+        id: deploy
+        uses: superfly/fly-pr-review-apps@1.2.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ RUN uv sync
 
 EXPOSE 8080
 
-CMD ["uv", "run", "lt_app", "--server.port", "8080"]
+CMD ["uv", "run", "lt_app", "--server.port", "8080", "--server.address", "0.0.0.0"]

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,23 @@
+# fly.toml app configuration file generated for lactate-thresholds-green-thunder-7731 on 2025-01-08T22:11:14+01:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = 'lactate-thresholds-green-thunder-7731'
+primary_region = 'arn'
+
+[build]
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = 'stop'
+  auto_start_machines = true
+  min_machines_running = 0
+  max_machines_running = 1
+  processes = ['app']
+
+[[vm]]
+  memory = '1gb'
+  cpu_kind = 'shared'
+  cpus = 1


### PR DESCRIPTION
Followed the guide of [this link](https://fly.io/docs/blueprints/review-apps-guide/). 
Basically, on a PR open|sync|close|reopen -> will publish a review app to fly.io. 

Will be available at https://pr-<PR number>-<repository owner>-<repository name>.fly.dev

Currently unsure if it actually published on a commit to master
